### PR TITLE
Introduce new permission Jenkins.CONFIGURE_JENKINS and consolidate…

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -2103,7 +2103,11 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     }
     public static boolean FAST_LOOKUP = !SystemProperties.getBoolean(PluginManager.class.getName()+".noFastLookup");
 
+    @Deprecated
+    @Restricted(NoExternalUse.class)
     public static final Permission UPLOAD_PLUGINS = new Permission(Jenkins.PERMISSIONS, "UploadPlugins", Messages._PluginManager_UploadPluginsPermission_Description(),Jenkins.ADMINISTER,PermissionScope.JENKINS);
+    @Deprecated
+    @Restricted(NoExternalUse.class)
     public static final Permission CONFIGURE_UPDATECENTER = new Permission(Jenkins.PERMISSIONS, "ConfigureUpdateCenter", Messages._PluginManager_ConfigureUpdateCenterPermission_Description(),Jenkins.ADMINISTER,PermissionScope.JENKINS);
 
     /**

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -2104,9 +2104,11 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     public static boolean FAST_LOOKUP = !SystemProperties.getBoolean(PluginManager.class.getName()+".noFastLookup");
 
     @Deprecated
+    /** @deprecated as of TODO use {@link Jenkins#ADMINISTER} */
     @Restricted(NoExternalUse.class)
     public static final Permission UPLOAD_PLUGINS = new Permission(Jenkins.PERMISSIONS, "UploadPlugins", Messages._PluginManager_UploadPluginsPermission_Description(),Jenkins.ADMINISTER,PermissionScope.JENKINS);
     @Deprecated
+    /** @deprecated as of TODO use {@link Jenkins#ADMINISTER} */
     @Restricted(NoExternalUse.class)
     public static final Permission CONFIGURE_UPDATECENTER = new Permission(Jenkins.PERMISSIONS, "ConfigureUpdateCenter", Messages._PluginManager_ConfigureUpdateCenterPermission_Description(),Jenkins.ADMINISTER,PermissionScope.JENKINS);
 

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -1395,7 +1395,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
     @RequirePOST
     public HttpResponse doUpdateSources(StaplerRequest req) throws IOException {
-        Jenkins.get().checkPermission(CONFIGURE_UPDATECENTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         if (req.hasParameter("remove")) {
             UpdateCenter uc = Jenkins.get().getUpdateCenter();
@@ -1601,7 +1601,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @RequirePOST
     public HttpResponse doSiteConfigure(@QueryParameter String site) throws IOException {
         Jenkins hudson = Jenkins.get();
-        hudson.checkPermission(CONFIGURE_UPDATECENTER);
+        hudson.checkPermission(Jenkins.ADMINISTER);
         UpdateCenter uc = hudson.getUpdateCenter();
         PersistedList<UpdateSite> sites = uc.getSites();
         for (UpdateSite s : sites) {
@@ -1616,7 +1616,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @POST
     public HttpResponse doProxyConfigure(StaplerRequest req) throws IOException, ServletException {
         Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(CONFIGURE_UPDATECENTER);
+        jenkins.checkPermission(Jenkins.ADMINISTER);
 
         ProxyConfiguration pc = req.bindJSON(ProxyConfiguration.class, req.getSubmittedForm());
         if (pc.name==null) {
@@ -1635,7 +1635,7 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     @RequirePOST
     public HttpResponse doUploadPlugin(StaplerRequest req) throws IOException, ServletException {
         try {
-            Jenkins.get().checkPermission(UPLOAD_PLUGINS);
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
             ServletFileUpload upload = new ServletFileUpload(new DiskFileItemFactory());
 

--- a/core/src/main/java/hudson/cli/GroovyCommand.java
+++ b/core/src/main/java/hudson/cli/GroovyCommand.java
@@ -59,7 +59,7 @@ public class GroovyCommand extends CLICommand {
 
     protected int run() throws Exception {
         // this allows the caller to manipulate the JVM state, so require the execute script privilege.
-        Jenkins.getActiveInstance().checkPermission(Jenkins.RUN_SCRIPTS);
+        Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER);
 
         Binding binding = new Binding();
         binding.setProperty("out",new PrintWriter(stdout,true));

--- a/core/src/main/java/hudson/cli/GroovyshCommand.java
+++ b/core/src/main/java/hudson/cli/GroovyshCommand.java
@@ -60,7 +60,7 @@ public class GroovyshCommand extends CLICommand {
     @Override
     protected int run() {
         // this allows the caller to manipulate the JVM state, so require the admin privilege.
-        Jenkins.getActiveInstance().checkPermission(Jenkins.RUN_SCRIPTS);
+        Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER);
 
         // this being remote means no jline capability is available
         System.setProperty("jline.terminal", UnsupportedTerminal.class.getName());

--- a/core/src/main/java/hudson/cli/InstallPluginCommand.java
+++ b/core/src/main/java/hudson/cli/InstallPluginCommand.java
@@ -83,7 +83,7 @@ public class InstallPluginCommand extends CLICommand {
     @Override
     protected int run() throws Exception {
         Jenkins h = Jenkins.get();
-        h.checkPermission(PluginManager.UPLOAD_PLUGINS);
+        h.checkPermission(Jenkins.ADMINISTER);
         PluginManager pm = h.getPluginManager();
 
         if (name != null) {

--- a/core/src/main/java/hudson/util/RemotingDiagnostics.java
+++ b/core/src/main/java/hudson/util/RemotingDiagnostics.java
@@ -196,7 +196,7 @@ public final class RemotingDiagnostics {
 
         @WebMethod(name="heapdump.hprof")
         public void doHeapDump(StaplerRequest req, StaplerResponse rsp) throws IOException, InterruptedException {
-            owner.checkPermission(Jenkins.RUN_SCRIPTS);
+            owner.checkPermission(Jenkins.ADMINISTER);
             rsp.setContentType("application/octet-stream");
 
             FilePath dump = obtain();

--- a/core/src/main/java/jenkins/management/ConsoleLink.java
+++ b/core/src/main/java/jenkins/management/ConsoleLink.java
@@ -57,6 +57,6 @@ public class ConsoleLink extends ManagementLink {
 
     @Override
     public Permission getRequiredPermission() {
-        return Jenkins.RUN_SCRIPTS;
+        return Jenkins.ADMINISTER;
     }
 }

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5258,7 +5258,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     public static final PermissionGroup PERMISSIONS = Permission.HUDSON_PERMISSIONS;
     public static final Permission ADMINISTER = Permission.HUDSON_ADMINISTER;
     public static final Permission READ = new Permission(PERMISSIONS,"Read",Messages._Hudson_ReadPermission_Description(),Permission.READ,PermissionScope.JENKINS);
+    @Deprecated
+    @Restricted(NoExternalUse.class)
     public static final Permission RUN_SCRIPTS = new Permission(PERMISSIONS, "RunScripts", Messages._Hudson_RunScriptsPermission_Description(),ADMINISTER,PermissionScope.JENKINS);
+
+    public static final Permission CONFIGURE_JENKINS = new Permission(PERMISSIONS, "ConfigureJenkins", Messages._Hudson_ConfigureJenkins_Description(),ADMINISTER, PermissionScope.JENKINS);
 
     /**
      * Urls that are always visible without READ permission.

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5256,12 +5256,20 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     private static final Logger LOGGER = Logger.getLogger(Jenkins.class.getName());
 
     public static final PermissionGroup PERMISSIONS = Permission.HUDSON_PERMISSIONS;
+    /**
+     * Grants ability to configure any and all aspects of the Jenkins instance
+     */
     public static final Permission ADMINISTER = Permission.HUDSON_ADMINISTER;
     public static final Permission READ = new Permission(PERMISSIONS,"Read",Messages._Hudson_ReadPermission_Description(),Permission.READ,PermissionScope.JENKINS);
     @Deprecated
+    /** @deprecated as of TODO use {@link Jenkins#ADMINISTER} */
     @Restricted(NoExternalUse.class)
     public static final Permission RUN_SCRIPTS = new Permission(PERMISSIONS, "RunScripts", Messages._Hudson_RunScriptsPermission_Description(),ADMINISTER,PermissionScope.JENKINS);
 
+    /**
+     * Allows non-privilege escalating configuration permission for a Jenkins instance.  Actions which could result
+     * in a privilege  escalation (such as RUN_SCRIPTS) require explicit ADMINISTER permission
+     */
     public static final Permission CONFIGURE_JENKINS = new Permission(PERMISSIONS, "ConfigureJenkins", Messages._Hudson_ConfigureJenkins_Description(),ADMINISTER, PermissionScope.JENKINS);
 
     /**

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5270,7 +5270,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Allows non-privilege escalating configuration permission for a Jenkins instance.  Actions which could result
      * in a privilege  escalation (such as RUN_SCRIPTS) require explicit ADMINISTER permission
      */
-    public static final Permission CONFIGURE_JENKINS = new Permission(PERMISSIONS, "ConfigureJenkins", Messages._Hudson_ConfigureJenkins_Description(),ADMINISTER, PermissionScope.JENKINS);
+    public static final Permission CONFIGURE_JENKINS = new Permission(PERMISSIONS, "Configure", Messages._Hudson_ConfigureJenkins_Description(),ADMINISTER, PermissionScope.JENKINS);
 
     /**
      * Urls that are always visible without READ permission.

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4483,7 +4483,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     public static void _doScript(StaplerRequest req, StaplerResponse rsp, RequestDispatcher view, VirtualChannel channel, ACL acl) throws IOException, ServletException {
         // ability to run arbitrary script is dangerous
-        acl.checkPermission(RUN_SCRIPTS);
+        acl.checkPermission(ADMINISTER);
 
         String text = req.getParameter("script");
         if (text != null) {
@@ -4513,7 +4513,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      */
     @RequirePOST
     public void doEval(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        checkPermission(RUN_SCRIPTS);
+        checkPermission(ADMINISTER);
         req.getWebApp().getDispatchValidator().allowDispatch(req, rsp);
         try {
             MetaClass mc = req.getWebApp().getMetaClass(getClass());

--- a/core/src/main/java/jenkins/security/s2m/AdminWhitelistRule.java
+++ b/core/src/main/java/jenkins/security/s2m/AdminWhitelistRule.java
@@ -212,7 +212,7 @@ public class AdminWhitelistRule implements StaplerProxy {
     public void setMasterKillSwitch(boolean state) {
         final Jenkins jenkins = Jenkins.get();
         try {
-            jenkins.checkPermission(Jenkins.RUN_SCRIPTS);
+            jenkins.checkPermission(Jenkins.ADMINISTER);
             File f = getMasterKillSwitchFile(jenkins);
             FileUtils.writeStringToFile(f, Boolean.toString(state), Charset.defaultCharset());
             // treat the file as the canonical source of information in case write fails
@@ -227,7 +227,7 @@ public class AdminWhitelistRule implements StaplerProxy {
      */
     @Override
     public Object getTarget() {
-        Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         return this;
     }
 

--- a/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
+++ b/core/src/main/java/jenkins/security/s2m/MasterKillSwitchConfiguration.java
@@ -48,7 +48,7 @@ public class MasterKillSwitchConfiguration extends GlobalConfiguration {
      * Unless this option is relevant, we don't let users choose this.
      */
     public boolean isRelevant() {
-        return jenkins.hasPermission(Jenkins.RUN_SCRIPTS) && jenkins.isUseSecurity();
+        return jenkins.hasPermission(Jenkins.ADMINISTER) && jenkins.isUseSecurity();
     }
 }
 

--- a/core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
       <table id="pluginsAdv" class="pane" style="margin-top:0; border-top:none">
         <tr style="border-top:none; white-space: normal">
           <td>
-            <l:hasPermission permission="${app.pluginManager.CONFIGURE_UPDATECENTER}">
+            <l:hasPermission permission="${app.ADMINISTER}">
               <h1>${%HTTP Proxy Configuration}</h1>
               <f:form method="post" action="proxyConfigure" name="proxyConfigure">
                 <j:scope>
@@ -49,7 +49,7 @@ THE SOFTWARE.
               </f:form>
             </l:hasPermission>
 
-            <l:hasPermission permission="${app.pluginManager.UPLOAD_PLUGINS}">
+            <l:hasPermission permission="${app.ADMINISTER}">
               <h1>${%Upload Plugin}</h1>
               <f:form method="post" action="uploadPlugin" name="uploadPlugin" enctype="multipart/form-data">
                 <f:block>
@@ -66,7 +66,7 @@ THE SOFTWARE.
                 </f:block>
               </f:form>
             </l:hasPermission>
-            <l:hasPermission permission="${app.pluginManager.CONFIGURE_UPDATECENTER}">
+            <l:hasPermission permission="${app.ADMINISTER}">
               <h1>${%Update Site}</h1>
               <f:form method="post" action="siteConfigure" name="siteConfigure">
                 <f:entry title="${%URL}" >

--- a/core/src/main/resources/hudson/PluginManager/tabBar.jelly
+++ b/core/src/main/resources/hudson/PluginManager/tabBar.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
     <l:tab name="${%Updates}" active="${page=='updates'}" href="." />
     <l:tab name="${%Available}" active="${page=='available'}" href="./available" />
     <l:tab name="${%Installed}" active="${page=='installed'}" href="./installed" />
-  <j:if test="${h.hasPermission(app.pluginManager.UPLOAD_PLUGINS) || h.hasPermission(app.pluginManager.CONFIGURE_UPDATECENTER)}">
+  <j:if test="${h.hasPermission(app.ADMINISTER)}">
     <l:tab name="${%Advanced}" active="${page=='advanced'}" href="./advanced" />
   </j:if>
   </l:tabBar>

--- a/core/src/main/resources/hudson/model/Computer/sidepanel.jelly
+++ b/core/src/main/resources/hudson/model/Computer/sidepanel.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
       <l:task href="${rootURL}/${it.url}builds" icon="icon-notepad icon-md" title="${%Build History}"/>
       <l:task href="${rootURL}/${it.url}load-statistics" icon="icon-monitor icon-md" title="${%Load Statistics}"/>
       <j:if test="${it.channel!=null}">
-        <l:task href="${rootURL}/${it.url}script" icon="icon-terminal icon-md" permission="${app.RUN_SCRIPTS}" title="${%Script Console}"/>
+        <l:task href="${rootURL}/${it.url}script" icon="icon-terminal icon-md" permission="${app.ADMINISTER}" title="${%Script Console}"/>
       </j:if>
       <st:include page="sidepanel2.jelly" optional="true" /><!-- hook for derived class to add more items -->
       <t:actions />

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -163,6 +163,9 @@ Hudson.AdministerPermission.Description=\
   This permission grants the ability to make system-wide configuration changes, \
   as well as perform highly sensitive operations that amounts to full local system access \
   (within the scope granted by the underlying OS.)
+
+Hudson.ConfigureJenkins.Description=Required to make non-sensitive configuration changes 
+
 Hudson.ReadPermission.Description=\
   The read permission is necessary for viewing almost all pages of Jenkins. \
   This permission is useful when you don\u2019t want unauthenticated users to see \

--- a/core/src/main/resources/hudson/model/Messages.properties
+++ b/core/src/main/resources/hudson/model/Messages.properties
@@ -164,7 +164,8 @@ Hudson.AdministerPermission.Description=\
   as well as perform highly sensitive operations that amounts to full local system access \
   (within the scope granted by the underlying OS.)
 
-Hudson.ConfigureJenkins.Description=Required to make non-sensitive configuration changes 
+Hudson.ConfigureJenkins.Description=This permission grants the ability to make non Permission escalating system configuration changes. \
+  System configuration which would allow the execution of arbitrary commands or code on the master requires Administer. 
 
 Hudson.ReadPermission.Description=\
   The read permission is necessary for viewing almost all pages of Jenkins. \

--- a/core/src/main/resources/jenkins/security/s2m/AdminWhitelistRule/index.jelly
+++ b/core/src/main/resources/jenkins/security/s2m/AdminWhitelistRule/index.jelly
@@ -23,7 +23,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-<l:layout title="${%Whitelist}" permission="${app.RUN_SCRIPTS}">
+<l:layout title="${%Whitelist}" permission="${app.ADMINISTER}">
   <st:include page="sidepanel.jelly" it="${app}"/>
   <l:main-panel>
     <h1>${%Agent &#8594; Master Access Control}</h1>

--- a/core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:f="/lib/form">
-  <l:layout norefresh="true" permission="${h.RUN_SCRIPTS}">
+  <l:layout norefresh="true" permission="${h.ADMINISTER}">
     <st:include page="sidepanel.jelly" />
 
     <l:main-panel>

--- a/test/src/test/java/hudson/cli/GroovyshCommandTest.java
+++ b/test/src/test/java/hudson/cli/GroovyshCommandTest.java
@@ -41,7 +41,7 @@ public class GroovyshCommandTest {
     @Issue("JENKINS-17929")
     @Test public void authentication() throws Exception {
         CLICommandInvoker.Result result = new CLICommandInvoker(r, new GroovyshCommand())
-            .authorizedTo(Jenkins.READ, Jenkins.RUN_SCRIPTS)
+            .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
             .withStdin(new StringInputStream("println(jenkins.model.Jenkins.instance.getClass().name)\n:quit\n"))
             .invoke();
         assertThat(result, succeeded());


### PR DESCRIPTION
Mark RUN_SCRIPTS, UPLOAD_PLUGINS, and CONFIGURE_UPDATECENTER as deprecated/no external use. These permission types will be
replaced by Jenkins.ADMINISTER

Introduce a new permission type, CONFIGURE_JENKINS, intended to be used
for configuring non-sensitive aspects of an instance.

** A full description + changelog will be created when a PR for the safer_permissions branch is created against jenkins/master **
<!-- Comment: 
A great PR typically begins with the line below.
Replace XXXXX with the numeric part of the issue's id you created on JIRA.
Please note that if you want your changes backported into LTS, you will need to create a JIRA ticket for it. Read https://jenkins.io/download/lts/#backporting-process for more.
-->
See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).

 * We do not require JIRA issues for minor improvements.
 * Bugfixes should have a JIRA issue (backporting process).
 * Major new features should have a JIRA issue reference.
-->

### Proposed changelog entries

* Entry 1: Issue, Human-readable Text
* ...

<!-- Comment: 
The changelogs will be integrated by the core maintainers after the merge.  See the changelog examples here: https://jenkins.io/changelog/ -->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Changelog entry appropriate for the audience affected by the change (users or developer, depending on the change). [Examples](https://github.com/jenkins-infra/jenkins.io/blob/master/content/_data/changelogs/weekly.yml)
      * Use the `Internal: ` prefix if the change has no user-visible impact (API, test frameworks, etc.)
- [ ] Appropriate autotests or explanation to why this change has no tests
- [ ] For dependency updates: links to external changelogs and, if possible, full diffs

<!-- For new API and extension points: Link to the reference implementation in open-source (or example in Javadoc) -->

### Desired reviewers

@mention

<!-- Comment:
If you need an accelerated review process by the community (e.g., for critical bugs), mention @jenkinsci/code-reviewers
-->
