### PR TITLE
READ impliedBy CONFIGURE impliedBy ADMINISTER

### DIFF
--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5260,17 +5260,19 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      * Grants ability to configure any and all aspects of the Jenkins instance
      */
     public static final Permission ADMINISTER = Permission.HUDSON_ADMINISTER;
-    public static final Permission READ = new Permission(PERMISSIONS,"Read",Messages._Hudson_ReadPermission_Description(),Permission.READ,PermissionScope.JENKINS);
-    @Deprecated
-    /** @deprecated as of TODO use {@link Jenkins#ADMINISTER} */
-    @Restricted(NoExternalUse.class)
-    public static final Permission RUN_SCRIPTS = new Permission(PERMISSIONS, "RunScripts", Messages._Hudson_RunScriptsPermission_Description(),ADMINISTER,PermissionScope.JENKINS);
 
     /**
      * Allows non-privilege escalating configuration permission for a Jenkins instance.  Actions which could result
      * in a privilege  escalation (such as RUN_SCRIPTS) require explicit ADMINISTER permission
      */
     public static final Permission CONFIGURE_JENKINS = new Permission(PERMISSIONS, "Configure", Messages._Hudson_ConfigureJenkins_Description(),ADMINISTER, PermissionScope.JENKINS);
+    
+    public static final Permission READ = new Permission(PERMISSIONS,"Read",Messages._Hudson_ReadPermission_Description(),CONFIGURE_JENKINS,PermissionScope.JENKINS);
+    @Deprecated
+    /** @deprecated as of TODO use {@link Jenkins#ADMINISTER} */
+    @Restricted(NoExternalUse.class)
+    public static final Permission RUN_SCRIPTS = new Permission(PERMISSIONS, "RunScripts", Messages._Hudson_RunScriptsPermission_Description(),ADMINISTER,PermissionScope.JENKINS);
+
 
     /**
      * Urls that are always visible without READ permission.


### PR DESCRIPTION
We need to have this order of implies to have a good inheritance of permissions (if not, CONFIGURE_JENKINS will miss READ permission).