### PR TITLE
By default config item are for administer

### DIFF
--- a/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
+++ b/core/src/main/java/hudson/diagnosis/OldDataMonitor.java
@@ -39,6 +39,7 @@ import hudson.model.listeners.RunListener;
 import hudson.model.listeners.SaveableListener;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+import hudson.security.Permission;
 import hudson.util.RobustReflectionConverter;
 import hudson.util.VersionNumber;
 import java.io.IOException;
@@ -459,6 +460,11 @@ public class OldDataMonitor extends AdministrativeMonitor {
 
         public String getDisplayName() {
             return Messages.OldDataMonitor_DisplayName();
+        }
+
+        @Override
+        public Permission getRequiredPermission() {
+            return Jenkins.CONFIGURE_JENKINS;
         }
     }
 }

--- a/core/src/main/java/hudson/model/ManagementLink.java
+++ b/core/src/main/java/hudson/model/ManagementLink.java
@@ -115,7 +115,7 @@ public abstract class ManagementLink implements ExtensionPoint, Action {
      * @return permission required for user to access this management link, in addition to {@link Jenkins#ADMINISTER}
      */
     public @CheckForNull Permission getRequiredPermission() {
-        return Jenkins.CONFIGURE_JENKINS;
+        return Jenkins.ADMINISTER;
     }
 
     /**


### PR DESCRIPTION
On managementLink class , the default should be ADMINISTER, and then sub class should override getRequiredPermission with CONFIGURE if it's allowed to CONFIGURE. 

Done, and then the overide was missing for "Manage Old Data" So I added it.