### PR TITLE
Global security must be restricted to ADMINISTER

### DIFF
--- a/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
+++ b/core/src/main/resources/hudson/security/GlobalSecurityConfiguration/index.groovy
@@ -12,7 +12,7 @@ def f=namespace(lib.FormTagLib)
 def l=namespace(lib.LayoutTagLib)
 def st=namespace("jelly:stapler")
 
-l.layout(norefresh:true, permission:app.CONFIGURE_JENKINS, title:my.displayName, cssclass:request.getParameter('decorate')) {
+l.layout(norefresh:true, permission:app.ADMINISTER, title:my.displayName, cssclass:request.getParameter('decorate')) {
     l.main_panel {
         h1 {
             l.icon(class: 'icon-secure icon-xlg')


### PR DESCRIPTION
Problem: User with CONFIGURE permission can access and see global securty configuration on /configureSecurity
Fix: this page is now retricted to ADMINISTER