### PR TITLE
Jenkins homepage is ok for CONFIGURE_JENKINS without READ

### DIFF
--- a/core/src/main/java/hudson/security/ACL.java
+++ b/core/src/main/java/hudson/security/ACL.java
@@ -74,6 +74,34 @@ public abstract class ACL {
     }
 
     /**
+     * Checks if the current security principal has at least one of the listed permissions.
+     * @param permissions
+     *
+     * @throws AccessDeniedException
+     *      *      if the user doesn't have one permission at all.
+     */
+    public final void checkHasAtLeastOnePermission(@Nonnull Permission...permissions) {
+
+        if (permissions.length<1) {
+            return;
+        } else {
+            Authentication a = Jenkins.getAuthentication();
+            if (a == SYSTEM) {
+                return;
+            }
+
+            boolean hasPermission = false;
+            for (Permission p: permissions) {
+                hasPermission = hasPermission || hasPermission(a,p);
+            }
+
+            if(!hasPermission) {
+                throw new AccessDeniedException2(a,permissions[0]);
+            }
+        }
+    }
+
+    /**
      * Checks if the current security principal has this permission.
      *
      * @return false

--- a/core/src/main/java/hudson/security/AccessControlled.java
+++ b/core/src/main/java/hudson/security/AccessControlled.java
@@ -48,6 +48,13 @@ public interface AccessControlled {
     }
 
     /**
+     * Convenient short-cut for {@code getACL().checkHasAtLeastOnePermission(permissions)}
+     */
+    default void checkHasAtLeastOnePermission(Permission...permissions) throws AccessDeniedException {
+        getACL().checkHasAtLeastOnePermission(permissions);
+    }
+
+    /**
      * Convenient short-cut for {@code getACL().hasPermission(permission)}
      */
     default boolean hasPermission(@Nonnull Permission permission) {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -4755,12 +4755,11 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
 
     public Object getTarget() {
         try {
-            checkPermission(READ);
+            checkHasAtLeastOnePermission(READ,CONFIGURE_JENKINS);
         } catch (AccessDeniedException e) {
             if (!isSubjectToMandatoryReadPermissionCheck(Stapler.getCurrentRequest().getRestOfPath())) {
                 return this;
             }
-
             throw e;
         }
         return this;

--- a/core/src/test/java/hudson/security/ACLTest.java
+++ b/core/src/test/java/hudson/security/ACLTest.java
@@ -1,0 +1,79 @@
+package hudson.security;
+
+import javax.annotation.Nonnull;
+
+import org.acegisecurity.Authentication;
+import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.junit.Assert;
+import org.junit.Test;
+
+import jenkins.model.Jenkins;
+
+public class ACLTest {
+
+    Authentication adminUser = new UsernamePasswordAuthenticationToken("admin","admin");
+    Authentication configUSer = new UsernamePasswordAuthenticationToken("config","config");
+    Authentication readUser = new UsernamePasswordAuthenticationToken("read","read");
+    DummyACL dummyACL = new DummyACL();
+
+    @Test
+    public void userWithPermissionShouldBeOk() {
+
+        DummyACL.as(adminUser);
+        dummyACL.checkPermission(Jenkins.ADMINISTER);
+
+        DummyACL.as(configUSer);
+        dummyACL.checkPermission(Jenkins.CONFIGURE_JENKINS);
+
+        DummyACL.as(readUser);
+        dummyACL.checkPermission(Jenkins.READ);
+
+    }
+
+    @Test
+    public void userWithoutPermissionShouldRaiseException() {
+
+        try {
+            DummyACL.as(Jenkins.ANONYMOUS);
+            dummyACL.checkPermission(Jenkins.ADMINISTER);
+            Assert.fail("An AccessDeniedException2 should be raised.");
+
+        } catch (AccessDeniedException2 e){
+            //We want that to happen
+        }
+
+    }
+
+    @Test
+    public void userWithOneRequiredPermissionShouldBeOk(){
+        DummyACL.as(adminUser);
+        dummyACL.checkHasAtLeastOnePermission(Jenkins.ADMINISTER, Jenkins.CONFIGURE_JENKINS);
+    }
+
+    @Test
+    public void userWithoutRequiredPermissionShouldThrowsException(){
+        try {
+            DummyACL.as(readUser);
+            dummyACL.checkHasAtLeastOnePermission(Jenkins.ADMINISTER, Jenkins.CONFIGURE_JENKINS);
+            Assert.fail("An AccessDeniedException2 should be raised.");
+        } catch (AccessDeniedException2 e){
+            //We want that to happen
+        }
+    }
+
+    /**
+     * Dummy ACL, one user per permission.
+     */
+    class DummyACL extends ACL {
+
+        @Override
+        public boolean hasPermission(@Nonnull Authentication a, @Nonnull Permission permission) {
+            return (a.getName().equals("admin") && Jenkins.ADMINISTER.equals(permission))
+                   || (a.getName().equals("config") && Jenkins.CONFIGURE_JENKINS.equals(permission))
+                   || (a.getName().equals("read") && Jenkins.READ.equals(permission)) ;
+        }
+    }
+
+}
+
+


### PR DESCRIPTION
A user should be able to configure only, without READ permission, so a CONFIGURE_JENKINS should be able to show the Jenkins homepage without needing READ.