### PR TITLE
FGP: Fix some authorizations and their tests, and add some new ones

### DIFF
--- a/core/src/main/java/hudson/model/AdministrativeMonitor.java
+++ b/core/src/main/java/hudson/model/AdministrativeMonitor.java
@@ -162,7 +162,7 @@ public abstract class AdministrativeMonitor extends AbstractModelObject implemen
     }
 
     /**
-     * Requires CONFIGURE_JENKINS permission for any operation in here.
+     * Requires ADMINISTER permission for any operation in here.
      */
     @Restricted(NoExternalUse.class)
     public Object getTarget() {

--- a/core/src/main/java/hudson/model/Fingerprint.java
+++ b/core/src/main/java/hudson/model/Fingerprint.java
@@ -123,7 +123,7 @@ public class Fingerprint implements ModelObject, Saveable {
          *      or if the current user has {@link Jenkins#ADMINISTER} permissions.
          *      If the job exists, but the current user has no permission to discover it, 
          *      {@code false}  will be returned.
-         *      If the job has been deleted and the user has no {@link Jenkins#CONFIGURE_JENKINS} permissions,
+         *      If the job has been deleted and the user has no {@link Jenkins#ADMINISTER} permissions,
          *      it also returns {@code false}   in order to avoid the job existence fact exposure.
          */
         private boolean hasPermissionToDiscoverBuild() {

--- a/core/src/main/java/jenkins/management/AdministrativeMonitorsConfiguration.java
+++ b/core/src/main/java/jenkins/management/AdministrativeMonitorsConfiguration.java
@@ -27,6 +27,8 @@ package jenkins.management;
 import hudson.Extension;
 import hudson.model.AdministrativeMonitor;
 import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
+
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
@@ -42,6 +44,9 @@ import java.util.logging.Logger;
 public class AdministrativeMonitorsConfiguration extends GlobalConfiguration {
     @Override
     public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)){
+            return true;
+        }
         JSONArray monitors = json.optJSONArray("administrativeMonitor");
         for (AdministrativeMonitor am : AdministrativeMonitor.all()) {
             try {

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -1890,7 +1890,9 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
      }
 
     public void setPrimaryView(@Nonnull View v) {
-        this.primaryView = v.getViewName();
+        if (hasPermission(ADMINISTER)) {
+            this.primaryView = v.getViewName();
+        }
     }
 
     public ViewsTabBar getViewsTabBar() {

--- a/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.groovy
+++ b/core/src/main/resources/jenkins/management/AdministrativeMonitorsConfiguration/config.groovy
@@ -25,28 +25,31 @@
 package jenkins.management.AdministrativeMonitorsConfiguration
 
 import hudson.model.AdministrativeMonitor
+import jenkins.model.Jenkins
 
 f = namespace(lib.FormTagLib)
 st = namespace("jelly:stapler")
 
-f.section(title: _("Administrative monitors configuration")) {
-    f.advanced(title: _("Administrative monitors")) {
-        f.entry(title: _("Enabled administrative monitors")) {
-            p(_("blurb"))
-            table(width: "100%") {
-                for (AdministrativeMonitor am : AdministrativeMonitor.all()) {
-                    f.block() {
-                        f.checkbox(name: "administrativeMonitor",
-                                title: am.displayName,
-                                checked: am.enabled,
-                                json: am.id)
-                    }
-                    tr() {
-                        td(colspan: "2")
-                        td(class: "setting-description") {
-                            st.include(from: am, page: "description", optional: true)
+if (Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+    f.section(title: _("Administrative monitors configuration")) {
+        f.advanced(title: _("Administrative monitors")) {
+            f.entry(title: _("Enabled administrative monitors")) {
+                p(_("blurb"))
+                table(width: "100%") {
+                    for (AdministrativeMonitor am : AdministrativeMonitor.all()) {
+                        f.block() {
+                            f.checkbox(name: "administrativeMonitor",
+                                    title: am.displayName,
+                                    checked: am.enabled,
+                                    json: am.id)
                         }
-                        td()
+                        tr() {
+                            td(colspan: "2")
+                            td(class: "setting-description") {
+                                st.include(from: am, page: "description", optional: true)
+                            }
+                            td()
+                        }
                     }
                 }
             }

--- a/test/src/test/java/hudson/AboutJenkinsTest.java
+++ b/test/src/test/java/hudson/AboutJenkinsTest.java
@@ -47,13 +47,15 @@ public class AboutJenkinsTest {
     
     @Test
     @Issue("SECURITY-771")
-    public void onlyAdminCanReadAbout() throws Exception {
+    public void onlyConfiguratorOrAdminCanReadAbout() throws Exception {
         final String ADMIN = "admin";
+        final String CONFIGURATOR = "configurator";
         final String USER = "user";
         
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                 .grant(Jenkins.ADMINISTER).everywhere().to(ADMIN)
+                .grant(Jenkins.CONFIGURE_JENKINS, Jenkins.READ).everywhere().to(CONFIGURATOR)
                 .grant(Jenkins.READ).everywhere().to(USER)
         );
         
@@ -65,9 +67,16 @@ public class AboutJenkinsTest {
             HtmlPage page = wc.goTo("about/");
             assertEquals(HttpURLConnection.HTTP_FORBIDDEN, page.getWebResponse().getStatusCode());
         }
-        
+
         { // admin can access it
             wc.login(ADMIN);
+            HtmlPage page = wc.goTo("about/");
+            assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
+            assertThat(page.getWebResponse().getContentAsString(), containsString("Mavenized dependencies"));
+        }
+        
+        { // configurator can access it
+            wc.login(CONFIGURATOR);
             HtmlPage page = wc.goTo("about/");
             assertEquals(HttpURLConnection.HTTP_OK, page.getWebResponse().getStatusCode());
             assertThat(page.getWebResponse().getContentAsString(), containsString("Mavenized dependencies"));

--- a/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
@@ -91,9 +91,12 @@ public class CancelQuietDownCommandTest {
 
     @Test
     public void cancelQuietDownShouldSuccessWithConfigurePermission() throws Exception {
+        //GIVEN a user with CONFIGURE_JENKINS permission
+        //WHEN cancel quiet down is called
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.CONFIGURE_JENKINS)
                 .invoke();
+        //THEN cancel quietDown worked
         assertThat(result, succeededSilently());
         QuietDownCommandTest.assertJenkinsNotInQuietMode(j);
     }

--- a/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/CancelQuietDownCommandTest.java
@@ -66,7 +66,7 @@ public class CancelQuietDownCommandTest {
                 .invoke();
         assertThat(result, failedWith(6));
         assertThat(result, hasNoStandardOutput());
-        assertThat(result.stderr(), containsString("ERROR: user is missing the Overall/Administer permission"));
+        assertThat(result.stderr(), containsString("ERROR: user is missing the Overall/Configure permission"));
     }
 
     @Test
@@ -84,6 +84,15 @@ public class CancelQuietDownCommandTest {
         QuietDownCommandTest.assertJenkinsInQuietMode(j);
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)
+                .invoke();
+        assertThat(result, succeededSilently());
+        QuietDownCommandTest.assertJenkinsNotInQuietMode(j);
+    }
+
+    @Test
+    public void cancelQuietDownShouldSuccessWithConfigurePermission() throws Exception {
+        final CLICommandInvoker.Result result = command
+                .authorizedTo(Jenkins.READ, Jenkins.CONFIGURE_JENKINS)
                 .invoke();
         assertThat(result, succeededSilently());
         QuietDownCommandTest.assertJenkinsNotInQuietMode(j);

--- a/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
@@ -332,12 +332,15 @@ public class DisablePluginCommandTest {
     @WithPlugin({"depender-0.0.2.hpi", "dependee-0.0.2.hpi"})
     public void configuratorCanNotDisablePlugin() {
 
+        //GIVEN a user with CONFIGURE_JENKINS permission
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                 .grant(Jenkins.CONFIGURE_JENKINS).everywhere().to("configurator")
         );
 
+        //WHEN trying to disable a plugin
         assertThat(disablePluginsCLiCommandAs("configurator", "dependee"), failedWith(6));
+        //THEN it's refused and the plugin is not disabled.
         assertPluginEnabled("dependee");
     }
 

--- a/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
+++ b/test/src/test/java/hudson/cli/DisablePluginCommandTest.java
@@ -33,6 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.recipes.WithPlugin;
 
 import java.io.IOException;
@@ -46,6 +47,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.*;
 import org.junit.Ignore;
+import jenkins.model.Jenkins;
 
 public class DisablePluginCommandTest {
 
@@ -326,6 +328,19 @@ public class DisablePluginCommandTest {
         assertTrue("Only error NOT_DISABLED_DEPENDANTS in quiet mode", checkResultWith(result, StringUtils::startsWith, "dependee", PluginWrapper.PluginDisableStatus.NOT_DISABLED_DEPENDANTS));
     }
 
+    @Test
+    @WithPlugin({"depender-0.0.2.hpi", "dependee-0.0.2.hpi"})
+    public void configuratorCanNotDisablePlugin() {
+
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.CONFIGURE_JENKINS).everywhere().to("configurator")
+        );
+
+        assertThat(disablePluginsCLiCommandAs("configurator", "dependee"), failedWith(6));
+        assertPluginEnabled("dependee");
+    }
+
     /**
      * Helper method to check the output of a result with a specific method allowing two arguments (
      * StringUtils::startsWith or StringUtils::contents). This method avoid to have it hardcoded the messages. We avoid
@@ -363,6 +378,16 @@ public class DisablePluginCommandTest {
      */
     private CLICommandInvoker.Result disablePluginsCLiCommand(String... args) {
         return new CLICommandInvoker(j, new DisablePluginCommand()).invokeWithArgs(args);
+    }
+
+    /**
+     * Disable a list of plugins using the CLI command.
+     * @param user Username
+     * @param args Arguments to pass to the command.
+     * @return Result of the command. 0 if succeed, 16 if some plugin couldn't be disabled due to dependent plugins.
+     */
+    private CLICommandInvoker.Result disablePluginsCLiCommandAs(String user, String... args) {
+        return new CLICommandInvoker(j, new DisablePluginCommand()).asUser(user).invokeWithArgs(args);
     }
 
     private void assertPluginDisabled(String name) {

--- a/test/src/test/java/hudson/cli/QuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/QuietDownCommandTest.java
@@ -78,7 +78,7 @@ public class QuietDownCommandTest {
                 .invoke();
         assertThat(result, failedWith(6));
         assertThat(result, hasNoStandardOutput());
-        assertThat(result.stderr(), containsString("ERROR: user is missing the Overall/Administer permission"));
+        assertThat(result.stderr(), containsString("ERROR: user is missing the Overall/Configure permission"));
     }
 
     @Test

--- a/test/src/test/java/hudson/cli/QuietDownCommandTest.java
+++ b/test/src/test/java/hudson/cli/QuietDownCommandTest.java
@@ -91,6 +91,15 @@ public class QuietDownCommandTest {
     }
 
     @Test
+    public void quietDownShouldSuccessWithConfigurePermission() throws Exception {
+        final CLICommandInvoker.Result result = command
+                .authorizedTo(Jenkins.READ, Jenkins.CONFIGURE_JENKINS)
+                .invoke();
+        assertThat(result, succeededSilently());
+        assertJenkinsInQuietMode();
+    }
+
+    @Test
     public void quietDownShouldSuccessWithBlock() throws Exception {
         final CLICommandInvoker.Result result = command
                 .authorizedTo(Jenkins.READ, Jenkins.ADMINISTER)

--- a/test/src/test/java/hudson/cli/ReloadConfigurationCommandTest.java
+++ b/test/src/test/java/hudson/cli/ReloadConfigurationCommandTest.java
@@ -68,13 +68,21 @@ public class ReloadConfigurationCommandTest {
     }
 
     @Test
-    public void reloadConfigurationShouldFailWithoutAdministerPermission() throws Exception {
+    public void reloadConfigurationShouldFailWithoutAdministerOrConfigurePermission() throws Exception {
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().toAuthenticated());
         final CLICommandInvoker.Result result = command.invoke();
 
         assertThat(result, failedWith(6));
         assertThat(result, hasNoStandardOutput());
-        assertThat(result.stderr(), containsString("user is missing the Overall/Administer permission"));
+        assertThat(result.stderr(), containsString("user is missing the Overall/Configure permission"));
+    }
+
+    @Test
+    public void reloadConfigurationShouldWorkWithConfigurePermission() throws Exception {
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                                   .grant(Jenkins.CONFIGURE_JENKINS, Jenkins.READ).everywhere().toAuthenticated());
+        //Any reload configuration should work with CONFIGURE_JENKINS as well
+        this.reloadMasterConfig();
     }
 
     @Test

--- a/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
+++ b/test/src/test/java/hudson/logging/LogRecorderManagerTest.java
@@ -75,7 +75,8 @@ public class LogRecorderManagerTest {
     /**
      * Makes sure that the logger configuration works with {@link Jenkins#CONFIGURE_JENKINS} permission
      */
-    @Test public void loggerConfigWithConfigurePermissionAllowed() throws Exception {
+    @Test
+    public void loggerConfigWithConfigurePermissionAllowed() throws Exception {
         final String CONFIGURATOR = "configurator";
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()

--- a/test/src/test/java/hudson/model/ComputerSetTest.java
+++ b/test/src/test/java/hudson/model/ComputerSetTest.java
@@ -87,6 +87,7 @@ public class ComputerSetTest {
 
     @Test
     public void monitorDisplayedWithConfigurePermission() throws Exception {
+        //GIVEN a user with CONFIGURE_JENKINS permission
         final String CONFIGURATOR = "configurator";
 
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
@@ -94,8 +95,10 @@ public class ComputerSetTest {
                                                    .grant(Jenkins.CONFIGURE_JENKINS, Jenkins.READ).everywhere().to(CONFIGURATOR));
 
         {
+            //WHEN the user go to Monitors
             WebClient client = j.createWebClient();
             HtmlPage page = client.withBasicCredentials(CONFIGURATOR).goTo("computer");
+            //THEN the user can see monitor information
             assertCanSeeMonitor(page, "Free Disk Space");
             assertCanSeeMonitor(page, "Free Swap Space");
             assertCanSeeMonitor(page, "Free Temp Space");
@@ -104,13 +107,16 @@ public class ComputerSetTest {
 
     @Test
     public void monitorNotDisplayedWithoutConfigurePermission() throws Exception {
+        //GIVEN a user with only READ permission
         final String USER = "user";
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().to(USER));
 
         {
+            //WHEN the user goes to monitor
             WebClient client = j.createWebClient();
             HtmlPage page = client.withBasicCredentials(USER).goTo("computer");
+            //THEN the user is not able to see information.
             assertCanNotSeeMonitor(page, "Free Disk Space");
             assertCanNotSeeMonitor(page, "Free Swap Space");
             assertCanNotSeeMonitor(page, "Free Temp Space");

--- a/test/src/test/java/hudson/model/ComputerSetTest.java
+++ b/test/src/test/java/hudson/model/ComputerSetTest.java
@@ -23,7 +23,9 @@
  */
 package hudson.model;
 
+import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.cli.CLICommandInvoker;
 import hudson.slaves.DumbSlave;
 import static org.hamcrest.Matchers.*;
@@ -33,6 +35,8 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import jenkins.model.Jenkins;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -79,5 +83,63 @@ public class ComputerSetTest {
         assertThat(ComputerSet.getComputerNames(), contains("aNode"));
         j.createSlave("anAnotherNode", "", null);
         assertThat(ComputerSet.getComputerNames(), containsInAnyOrder("aNode", "anAnotherNode"));
+    }
+
+    @Test
+    public void monitorDisplayedWithConfigurePermission() throws Exception {
+        final String CONFIGURATOR = "configurator";
+
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                                                   .grant(Jenkins.CONFIGURE_JENKINS, Jenkins.READ).everywhere().to(CONFIGURATOR));
+
+        {
+            WebClient client = j.createWebClient();
+            HtmlPage page = client.withBasicCredentials(CONFIGURATOR).goTo("computer");
+            assertCanSeeMonitor(page, "Free Disk Space");
+            assertCanSeeMonitor(page, "Free Swap Space");
+            assertCanSeeMonitor(page, "Free Temp Space");
+        }
+    }
+
+    @Test
+    public void monitorNotDisplayedWithoutConfigurePermission() throws Exception {
+        final String USER = "user";
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().to(USER));
+
+        {
+            WebClient client = j.createWebClient();
+            HtmlPage page = client.withBasicCredentials(USER).goTo("computer");
+            assertCanNotSeeMonitor(page, "Free Disk Space");
+            assertCanNotSeeMonitor(page, "Free Swap Space");
+            assertCanNotSeeMonitor(page, "Free Temp Space");
+        }
+    }
+
+    /**
+     * Tests that user with {@link Jenkins#CONFIGURE_JENKINS} can submit configuration form
+     */
+    @Test
+    public void configurationSuccessWithConfigurePermission() throws Exception {
+        final String CONFIGURATOR = "configurator";
+
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                                                   .grant(Jenkins.READ, Jenkins.CONFIGURE_JENKINS).everywhere().to(CONFIGURATOR));
+
+        WebClient client = j.createWebClient();
+        HtmlForm form = client.login(CONFIGURATOR).goTo("computer/configure").getFormByName("config");
+        j.submit(form);
+    }
+
+    private void assertCanSeeMonitor(HtmlPage page, String label) {
+        HtmlAnchor result = page.getFirstByXPath("//*[@id=\"computers\"]//*[contains(text(),'" + label + "')]");
+        assertNotNull("Monitor '"+label+"' should be displayed", result);
+    }
+
+    private void assertCanNotSeeMonitor(HtmlPage page, String label) {
+        HtmlAnchor result = page.getFirstByXPath("//*[@id=\"computers\"]//*[contains(text(),'" + label + "')]");
+        assertNull("Monitor '"+label+"' shouldn't be displayed", result);
     }
 }

--- a/test/src/test/java/hudson/model/ComputerSetTest.java
+++ b/test/src/test/java/hudson/model/ComputerSetTest.java
@@ -93,16 +93,13 @@ public class ComputerSetTest {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                                                    .grant(Jenkins.CONFIGURE_JENKINS, Jenkins.READ).everywhere().to(CONFIGURATOR));
-
-        {
-            //WHEN the user go to Monitors
-            WebClient client = j.createWebClient();
-            HtmlPage page = client.withBasicCredentials(CONFIGURATOR).goTo("computer");
-            //THEN the user can see monitor information
-            assertCanSeeMonitor(page, "Free Disk Space");
-            assertCanSeeMonitor(page, "Free Swap Space");
-            assertCanSeeMonitor(page, "Free Temp Space");
-        }
+        //WHEN the user go to Monitors
+        WebClient client = j.createWebClient();
+        HtmlPage page = client.withBasicCredentials(CONFIGURATOR).goTo("computer");
+        //THEN the user can see monitor information
+        assertCanSeeMonitor(page, "Free Disk Space");
+        assertCanSeeMonitor(page, "Free Swap Space");
+        assertCanSeeMonitor(page, "Free Temp Space");
     }
 
     @Test

--- a/test/src/test/java/hudson/model/ComputerTest.java
+++ b/test/src/test/java/hudson/model/ComputerTest.java
@@ -46,6 +46,7 @@ import org.junit.experimental.categories.Category;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.SmokeTest;
 import org.jvnet.hudson.test.recipes.LocalData;
 
@@ -126,4 +127,31 @@ public class ComputerTest {
         assertEquals(2, c.getActions(A.class).size());
     }
 
+    @Test
+    public void dumpExportTableAllowedWithAdminPermission() throws Exception {
+        final String ADMIN = "admin";
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                                               .grant(Jenkins.ADMINISTER).everywhere().to(ADMIN));
+        Page form = j.createWebClient().login(ADMIN).goTo("computer/(master)/dumpExportTable", "text/plain");
+        assertEquals(form.getWebResponse().getStatusCode(), 200);
+    }
+
+    @Test
+    public void dumpExportTableAllowedWithConfigurePermission() throws Exception {
+        final String CONFIGURATOR = "configurator";
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                                               .grant(Jenkins.CONFIGURE_JENKINS, Jenkins.READ).everywhere().to(CONFIGURATOR));
+        Page form = j.createWebClient().login(CONFIGURATOR).goTo("computer/(master)/dumpExportTable", "text/plain");
+        assertEquals(form.getWebResponse().getStatusCode(), 200);
+    }
+
+    @Test
+    public void dumpExportTableForbiddenWithoutAdminOrConfigurePermission() throws Exception {
+        final String READER = "reader";
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().to(READER));
+        j.createWebClient().login(READER).assertFails("computer/(master)/dumpExportTable", 403);
+    }
 }

--- a/test/src/test/java/hudson/model/HudsonTest.java
+++ b/test/src/test/java/hudson/model/HudsonTest.java
@@ -116,25 +116,23 @@ public class HudsonTest {
 
     @Test
     public void someGlobalConfigCanNotBeModifiedWithConfigurePermission() throws Exception {
-        //GIVEN a user with CONFIGURE_JENKINS permission
+        //GIVEN the Global Configuration Form, with some changes unsaved
         int currentNumberExecutors = j.getInstance().getNumExecutors();
         View primary = j.getInstance().getPrimaryView();
         String shell = getShell();
-
         j.getInstance().addView(new ListView("otherView"));
 
-        //WHEN the user tries to configure executor with an HTTP Form request
         HtmlForm form = j.createWebClient().goTo("configure").getFormByName("config");
         form.getInputByName("_.numExecutors").setValueAttribute(""+(currentNumberExecutors+1));
         form.getSelectByName("primaryView").setSelectedAttribute("otherView", true);
         form.getInputByName("_.shell").setValueAttribute("/fakeShell");
 
-        //User has CONFIGURE_JENKINS permission only, so should't be allowed to post a change on number of executors
+        // WHEN a user with CONFIGURE_JENKINS permission only try to save those changes
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                                                    .grant(Jenkins.CONFIGURE_JENKINS, Jenkins.READ).everywhere().toEveryone());
         j.submit(form);
-        //THEN the value of restricted configuration should not change.
+        // THEN the changes on fields forbidden to a CONFIGURE_JENKINS permission are not saved
         assertEquals("shouldn't be allowed to change the number of executors", currentNumberExecutors, j.getInstance().getNumExecutors());
         assertEquals("shouldn't be allowed to change the primary view", primary, j.getInstance().getPrimaryView());
         assertEquals("shouldn't be allowed to change the shell executable", shell, getShell());

--- a/test/src/test/java/hudson/model/HudsonTest.java
+++ b/test/src/test/java/hudson/model/HudsonTest.java
@@ -96,12 +96,15 @@ public class HudsonTest {
 
     @Test
     public void someGlobalConfigurationIsNotDisplayedWithConfigurePermission() throws Exception {
+        //GIVEN a user with CONFIGURE_JENKINS permission
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                                                    .grant(Jenkins.CONFIGURE_JENKINS, Jenkins.READ).everywhere().toEveryone());
 
+        //WHEN the user goes to /configure page
         HtmlForm form = j.createWebClient().goTo("configure").getFormByName("config");
         String formText = form.asText();
+        //THEN items restricted to ADMINISTER only should not be displayed.
         assertThat("Shouldn't be able to configure # of executors", formText, not(containsString("executors")));
         assertThat("Shouldn't be able to configure Global properties", formText,
                    not(containsString("Global properties")));
@@ -113,13 +116,14 @@ public class HudsonTest {
 
     @Test
     public void someGlobalConfigCanNotBeModifiedWithConfigurePermission() throws Exception {
+        //GIVEN a user with CONFIGURE_JENKINS permission
         int currentNumberExecutors = j.getInstance().getNumExecutors();
         View primary = j.getInstance().getPrimaryView();
         String shell = getShell();
 
         j.getInstance().addView(new ListView("otherView"));
 
-        //Load the form without authz restrictions
+        //WHEN the user tries to configure executor with an HTTP Form request
         HtmlForm form = j.createWebClient().goTo("configure").getFormByName("config");
         form.getInputByName("_.numExecutors").setValueAttribute(""+(currentNumberExecutors+1));
         form.getSelectByName("primaryView").setSelectedAttribute("otherView", true);
@@ -130,6 +134,7 @@ public class HudsonTest {
         j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
                                                    .grant(Jenkins.CONFIGURE_JENKINS, Jenkins.READ).everywhere().toEveryone());
         j.submit(form);
+        //THEN the value of restricted configuration should not change.
         assertEquals("shouldn't be allowed to change the number of executors", currentNumberExecutors, j.getInstance().getNumExecutors());
         assertEquals("shouldn't be allowed to change the primary view", primary, j.getInstance().getPrimaryView());
         assertEquals("shouldn't be allowed to change the shell executable", shell, getShell());

--- a/test/src/test/java/hudson/model/HudsonTest.java
+++ b/test/src/test/java/hudson/model/HudsonTest.java
@@ -40,7 +40,9 @@ import hudson.security.SecurityRealm;
 import hudson.tasks.Ant;
 import hudson.tasks.BuildStep;
 import hudson.tasks.Ant.AntInstallation;
+import hudson.tasks.Shell;
 import jenkins.model.Jenkins;
+import static org.hamcrest.Matchers.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -48,6 +50,7 @@ import org.jvnet.hudson.test.Email;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.SmokeTest;
 import org.jvnet.hudson.test.recipes.LocalData;
 
@@ -77,6 +80,64 @@ public class HudsonTest {
         assertEquals(10, j.jenkins.getQuietPeriod());
         assertEquals(9, j.jenkins.getScmCheckoutRetryCount());
         assertEquals(8, j.jenkins.getNumExecutors());
+    }
+
+    @Test
+    public void globalConfigAllowedWithConfigurePermission() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+               .grant(Jenkins.CONFIGURE_JENKINS, Jenkins.READ).everywhere().toEveryone());
+
+        HtmlForm form = j.createWebClient().goTo("configure").getFormByName("config");
+        HtmlPage updated = j.submit(form);
+        assertEquals("User with CONFIGURE_JENKINS permission should be able to update global configuration",
+                     200, updated.getWebResponse().getStatusCode());
+    }
+
+    @Test
+    public void someGlobalConfigurationIsNotDisplayedWithConfigurePermission() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                                                   .grant(Jenkins.CONFIGURE_JENKINS, Jenkins.READ).everywhere().toEveryone());
+
+        HtmlForm form = j.createWebClient().goTo("configure").getFormByName("config");
+        String formText = form.asText();
+        assertThat("Shouldn't be able to configure # of executors", formText, not(containsString("executors")));
+        assertThat("Shouldn't be able to configure Global properties", formText,
+                   not(containsString("Global properties")));
+        assertThat("Shouldn't be able to configure Administrative monitors", formText, not(containsString(
+                "Administrative "
+                + "monitors")));
+        assertThat("Shouldn't be able to configure Shell", formText, not(containsString("Shell")));
+    }
+
+    @Test
+    public void someGlobalConfigCanNotBeModifiedWithConfigurePermission() throws Exception {
+        int currentNumberExecutors = j.getInstance().getNumExecutors();
+        View primary = j.getInstance().getPrimaryView();
+        String shell = getShell();
+
+        j.getInstance().addView(new ListView("otherView"));
+
+        //Load the form without authz restrictions
+        HtmlForm form = j.createWebClient().goTo("configure").getFormByName("config");
+        form.getInputByName("_.numExecutors").setValueAttribute(""+(currentNumberExecutors+1));
+        form.getSelectByName("primaryView").setSelectedAttribute("otherView", true);
+        form.getInputByName("_.shell").setValueAttribute("/fakeShell");
+
+        //User has CONFIGURE_JENKINS permission only, so should't be allowed to post a change on number of executors
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                                                   .grant(Jenkins.CONFIGURE_JENKINS, Jenkins.READ).everywhere().toEveryone());
+        j.submit(form);
+        assertEquals("shouldn't be allowed to change the number of executors", currentNumberExecutors, j.getInstance().getNumExecutors());
+        assertEquals("shouldn't be allowed to change the primary view", primary, j.getInstance().getPrimaryView());
+        assertEquals("shouldn't be allowed to change the shell executable", shell, getShell());
+    }
+
+    private String getShell() {
+        Descriptor descriptorByName = j.getInstance().getDescriptorByName("hudson.tasks.Shell");
+        return ((Shell.DescriptorImpl) descriptorByName).getShell();
     }
 
     /**

--- a/test/src/test/java/hudson/model/labels/LabelAtomPropertyTest.java
+++ b/test/src/test/java/hudson/model/labels/LabelAtomPropertyTest.java
@@ -23,14 +23,20 @@
  */
 package hudson.model.labels;
 
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import jenkins.model.Jenkins;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -67,5 +73,54 @@ public class LabelAtomPropertyTest {
         j.submit(j.createWebClient().goTo("label/foo/configure").getFormByName("config"));
         assertEquals(1,foo.getProperties().size());
         j.assertEqualDataBoundBeans(old, foo.getProperties().get(LabelAtomPropertyImpl.class));
+    }
+
+    /**
+     * Tests the configuration persistence between disk, memory, and UI.
+     */
+    @Test
+    public void configAllowedWithConfigurePermission() throws Exception {
+        final String CONFIGURATOR = "configurator";
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                                                   .grant(Jenkins.READ, Jenkins.CONFIGURE_JENKINS).everywhere().to(CONFIGURATOR));
+
+        LabelAtom label = j.jenkins.getLabelAtom("foo");
+
+        // it should survive the configuration roundtrip
+        HtmlForm labelConfigForm = j.createWebClient().login(CONFIGURATOR).goTo("label/foo/configure").getFormByName("config");
+        labelConfigForm.getTextAreaByName("description").setText("example description");
+        j.submit(labelConfigForm);
+
+        assertEquals("example description",label.getDescription());
+    }
+
+    /**
+     * Tests the configuration persistence between disk, memory, and UI.
+     */
+    @Test
+    public void configForbiddenWithoutConfigureOrAdminPermissions() throws Exception {
+        final String UNAUTHORIZED = "reader";
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.READ).everywhere().to(UNAUTHORIZED));
+
+        j.jenkins.getLabelAtom("foo");
+
+        // Unauthorized user can't be able to access the configuration form
+        JenkinsRule.WebClient webClient = j.createWebClient().login(UNAUTHORIZED).withThrowExceptionOnFailingStatusCode(false);
+        webClient.assertFails("label/foo/configure", 403);
+
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                                       .grant(Jenkins.ADMINISTER).everywhere().to(UNAUTHORIZED));
+
+        // And can't submit the form neither
+        HtmlForm labelConfigForm = webClient.goTo("label/foo/configure").getFormByName("config");
+        labelConfigForm.getTextAreaByName("description").setText("example description");
+
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                                                   .grant(Jenkins.READ).everywhere().to(UNAUTHORIZED));
+        HtmlPage submitted = j.submit(labelConfigForm);
+        assertEquals(403, submitted.getWebResponse().getStatusCode());
     }
 }

--- a/test/src/test/java/jenkins/model/JenkinsTest.java
+++ b/test/src/test/java/jenkins/model/JenkinsTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import com.gargoylesoftware.htmlunit.HttpMethod;
 import com.gargoylesoftware.htmlunit.Page;
@@ -41,6 +42,7 @@ import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
+import hudson.cli.CLICommandInvoker;
 import hudson.model.Computer;
 import hudson.model.Failure;
 import hudson.model.InvisibleAction;
@@ -62,6 +64,8 @@ import hudson.util.VersionNumber;
 
 import jenkins.AgentProtocol;
 import jenkins.security.apitoken.ApiTokenTestHelper;
+
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -86,6 +90,9 @@ import java.util.Set;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
 import javax.annotation.CheckForNull;
+
+import static hudson.cli.CLICommandInvoker.Matcher.failedWith;
+import static hudson.cli.CLICommandInvoker.Matcher.succeededSilently;
 
 /**
  * Tests of the {@link Jenkins} class instance logic.
@@ -703,4 +710,21 @@ public class JenkinsTest {
     public void jobCreatedByInitializerIsRetained() {
         assertNotNull("JENKINS-47406 should exist", j.jenkins.getItem("JENKINS-47406"));
     }
+
+    @Test
+    public void doExitSuccessWithConfigurePermission() {
+        CLICommandInvoker.Result result = new CLICommandInvoker(j, "shutdown")
+                .authorizedTo(Jenkins.READ, Jenkins.CONFIGURE_JENKINS)
+                .invoke();
+        assertThat(result, succeededSilently());
+    }
+
+    @Test
+    public void doSafeExitSuccessWithConfigurePermission() {
+        CLICommandInvoker.Result result = new CLICommandInvoker(j, "safe-shutdown")
+                .authorizedTo(Jenkins.READ, Jenkins.CONFIGURE_JENKINS)
+                .invoke();
+        assertThat(result, succeededSilently());
+    }
+
 }


### PR DESCRIPTION
What is changed:

- Fix some authorization of `CONFIGURE_JENKINS`:
  - Don't allow configure `Administrative Monitor`
- Fix some documentation, that said `CONFIGURE_JENKINS` when now it's `ADMINISTER`
- Fix some tests that checked the error message `user is missing the Overall/Administer permission`, and now they are checking for `Overall/Configure`
- Add new tests

Coverage of authorization with permission `CONFIGURE_JENKINS`:
- Can Not access:
    - `Plugin Management` view (can't see it or modify it)
    - `Administrative Monitor`
    - Some options of `Global configuration`
- Can:
    - `About Jenkins` view
    - `Shutdown`, `Restart` master allowed
    - `Log recorders` allowed
    - Export thread dumps
    - See and manage some options of `Global Configuration`
    - Label descriptions
    - Reload configuration files