### PR TITLE
Fix compatibility with Matrix Plugin

### DIFF
--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -2107,10 +2107,11 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
 
     /** @deprecated use {@link Jenkins#ADMINISTER} instead */
     @Deprecated
+    public static final Permission UPLOAD_PLUGINS = new Permission(Jenkins.PERMISSIONS, "UploadPlugins", Messages._PluginManager_UploadPluginsPermission_Description(),Jenkins.ADMINISTER,PermissionScope.JENKINS);
     public static final Permission UPLOAD_PLUGINS = Jenkins.ADMINISTER;
     /** @deprecated use {@link Jenkins#ADMINISTER} instead */
     @Deprecated
-    public static final Permission CONFIGURE_UPDATECENTER = Jenkins.ADMINISTER;
+    public static final Permission CONFIGURE_UPDATECENTER = new Permission(Jenkins.PERMISSIONS, "ConfigureUpdateCenter", Messages._PluginManager_ConfigureUpdateCenterPermission_Description(),Jenkins.ADMINISTER,PermissionScope.JENKINS);
 
     /**
      * Remembers why a plugin failed to deploy.

--- a/core/src/main/java/hudson/PluginManager.java
+++ b/core/src/main/java/hudson/PluginManager.java
@@ -2105,11 +2105,16 @@ public abstract class PluginManager extends AbstractModelObject implements OnMas
     }
     public static boolean FAST_LOOKUP = !SystemProperties.getBoolean(PluginManager.class.getName()+".noFastLookup");
 
-    /** @deprecated use {@link Jenkins#ADMINISTER} instead */
+    /**
+     * @deprecated since FIXME 2.XXX
+     * Use {@link Jenkins#ADMINISTER} instead
+     */
     @Deprecated
     public static final Permission UPLOAD_PLUGINS = new Permission(Jenkins.PERMISSIONS, "UploadPlugins", Messages._PluginManager_UploadPluginsPermission_Description(),Jenkins.ADMINISTER,PermissionScope.JENKINS);
-    public static final Permission UPLOAD_PLUGINS = Jenkins.ADMINISTER;
-    /** @deprecated use {@link Jenkins#ADMINISTER} instead */
+    /**
+     * @deprecated since FIXME 2.XXX
+     * Use {@link Jenkins#ADMINISTER} instead
+     */
     @Deprecated
     public static final Permission CONFIGURE_UPDATECENTER = new Permission(Jenkins.PERMISSIONS, "ConfigureUpdateCenter", Messages._PluginManager_ConfigureUpdateCenterPermission_Description(),Jenkins.ADMINISTER,PermissionScope.JENKINS);
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5269,7 +5269,10 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     public static final PermissionGroup PERMISSIONS = Permission.HUDSON_PERMISSIONS;
     public static final Permission ADMINISTER = Permission.HUDSON_ADMINISTER;
     public static final Permission READ = new Permission(PERMISSIONS,"Read",Messages._Hudson_ReadPermission_Description(),Permission.READ,PermissionScope.JENKINS);
-    /** @deprecated use {@link #ADMINISTER} instead */
+    /**
+     * @deprecated since FIXME 2.XXX
+     * Use {@link Jenkins#ADMINISTER} instead
+     */
     @Deprecated
     public static final Permission RUN_SCRIPTS = new Permission(PERMISSIONS, "RunScripts", Messages._Hudson_RunScriptsPermission_Description(),ADMINISTER,PermissionScope.JENKINS);
 

--- a/core/src/main/java/jenkins/model/Jenkins.java
+++ b/core/src/main/java/jenkins/model/Jenkins.java
@@ -5271,7 +5271,7 @@ public class Jenkins extends AbstractCIBase implements DirectlyModifiableTopLeve
     public static final Permission READ = new Permission(PERMISSIONS,"Read",Messages._Hudson_ReadPermission_Description(),Permission.READ,PermissionScope.JENKINS);
     /** @deprecated use {@link #ADMINISTER} instead */
     @Deprecated
-    public static final Permission RUN_SCRIPTS = ADMINISTER;
+    public static final Permission RUN_SCRIPTS = new Permission(PERMISSIONS, "RunScripts", Messages._Hudson_RunScriptsPermission_Description(),ADMINISTER,PermissionScope.JENKINS);
 
     /**
      * Urls that are always visible without READ permission.


### PR DESCRIPTION
Replacing the values of the _dangerous permissions_ by `Jenkins.ADMINISTER` breaks the compatibility with the Matrix Plugin (don't know about RBAC plugin).

In order to do this change, we first need to remove the usage of the following system properties:
* `hudson.security.GlobalMatrixAuthorizationStrategy.dangerousPermissions` in Matrix Plugin
* `org.jenkinsci.plugins.rolestrategy.permissions.DangerousPermissionHandlingMode.enableDangerousPermissions` in RBAC Plugin

More details about the issue fixed with this PR:

In Matrix plugin, if the previous system property is `true`, and you check if a user has a _dangerous permission_, the Strategy checks for `ADMINISTER` permission instead. If the _dangerous permissions_ points to the same instance than `ADMINISTER`, this cause an infinite recursion. See more here: https://github.com/jenkinsci/matrix-auth-plugin/blob/d4eb451b402a8e2b7e50aff83bbf717694b33d26/src/main/java/org/jenkinsci/plugins/matrixauth/AuthorizationContainer.java#L165

